### PR TITLE
Update 02_1_Kogito_Rules_Lab.adoc

### DIFF
--- a/modules/02_Kogito_Rules/02_1_Kogito_Rules_Lab.adoc
+++ b/modules/02_Kogito_Rules/02_1_Kogito_Rules_Lab.adoc
@@ -48,7 +48,7 @@ Kogito offers a powerful developer experience based on battle-tested components.
 * JDK 11+
 * Maven 3.6.3+
 * cURL (or another client/tool with which RESTful requests can be sent to the Kogito application)
-* GraalVM 20.x (Optional. Required if you want to run a native compilation)
+* GraalVM 20.x 
 
 In this step, you will create a Kogito application skeleton.
 


### PR DESCRIPTION
Removed this text for GraalVM pre-req "(Optional. Required if you want to run a native compilation)" In the instructions I think we are doing natice compilation.